### PR TITLE
Add note editing capability

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -23,6 +23,14 @@ function App() {
     setNotes(notes.filter(note => note.id !== id));
   };
 
+  const updateNote = (id, updatedContent) => {
+    setNotes(
+      notes.map((note) =>
+        note.id === id ? { ...note, content: updatedContent } : note
+      )
+    );
+  };
+
   return (
     <div className="app-container">
       <header className="app-header">
@@ -35,7 +43,13 @@ function App() {
         <NoteForm addNote={addNote} />
         <div className="notes-list">
           {notes.map((note) => (
-            <Note key={note.id} id={note.id} content={note.content} deleteNote={deleteNote} />
+            <Note
+              key={note.id}
+              id={note.id}
+              content={note.content}
+              deleteNote={deleteNote}
+              updateNote={updateNote}
+            />
           ))}
         </div>
       </main>

--- a/src/components/Note.js
+++ b/src/components/Note.js
@@ -1,12 +1,12 @@
-import React from 'react';
-import { 
-    DeleteRegular, 
-    DeleteFilled, 
-    bundleIcon,
-    iconFilledClassName,
-    iconRegularClassName,
+import React, { useState } from 'react';
+import {
+  DeleteRegular,
+  DeleteFilled,
+  bundleIcon,
+  iconFilledClassName,
+  iconRegularClassName,
 } from '@fluentui/react-icons';
-import { makeStyles } from '@fluentui/react-components';
+import { Input, Button, makeStyles } from '@fluentui/react-components';
 
 // Bundle the regular and filled versions of the Delete icon
 const DeleteIcon = bundleIcon(DeleteFilled, DeleteRegular);
@@ -15,14 +15,17 @@ const DeleteIcon = bundleIcon(DeleteFilled, DeleteRegular);
 const useIconStyles = makeStyles({
   iconContainer: {
     display: 'flex',
-    justifyContent: 'space-between',
     alignItems: 'center',
+  },
+  actions: {
+    display: 'flex',
+    alignItems: 'center',
+    marginLeft: 'auto',
   },
   icon: {
     fontSize: '1rem', // Set the icon size
-    marginLeft: 'auto', // Pushes the icon to the right
     cursor: 'pointer', // Changes the cursor on hover
-    ':hover': { // Changes the icon color on hover
+    ':hover': {
       [`& .${iconFilledClassName}`]: {
         display: 'none',
       },
@@ -30,6 +33,10 @@ const useIconStyles = makeStyles({
         display: 'inline',
       },
     },
+  },
+  editInput: {
+    flexGrow: 1,
+    marginRight: '0.5rem',
   },
 });
 
@@ -40,18 +47,55 @@ const useIconStyles = makeStyles({
 // TODO: Add a confirmation dialog before deleting a note
 // TODO: Rearrange the notes using drag and drop
 
-const Note = ({ id, content, deleteNote }) => {
+const Note = ({ id, content, deleteNote, updateNote }) => {
   const styles = useIconStyles();
-  
+  const [isEditing, setIsEditing] = useState(false);
+  const [editedContent, setEditedContent] = useState(content);
+
   const iconStyleProps = {
     primaryFill: 'currentColor', // Use the text color for the icon
     className: styles.icon,
   };
 
+  const handleSave = () => {
+    updateNote(id, editedContent);
+    setIsEditing(false);
+  };
+
   return (
     <div className={styles.iconContainer}>
-      {content}
-      <DeleteIcon {...iconStyleProps} onClick={() => deleteNote(id)} aria-label="Delete note" />
+      {isEditing ? (
+        <Input
+          className={styles.editInput}
+          value={editedContent}
+          onChange={(e) => setEditedContent(e.target.value)}
+        />
+      ) : (
+        <span>{content}</span>
+      )}
+      <div className={styles.actions}>
+        {isEditing ? (
+          <Button appearance="primary" size="small" onClick={handleSave}>
+            Save
+          </Button>
+        ) : (
+          <Button
+            appearance="secondary"
+            size="small"
+            onClick={() => {
+              setIsEditing(true);
+              setEditedContent(content);
+            }}
+          >
+            Edit
+          </Button>
+        )}
+        <DeleteIcon
+          {...iconStyleProps}
+          onClick={() => deleteNote(id)}
+          aria-label="Delete note"
+        />
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- allow notes to be edited by id with new `updateNote` function
- provide editing controls and save support within each Note component

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689cfedfa16c8329b513c49c9a2f64a7